### PR TITLE
feat: release manually

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,6 @@
 name: Release
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
the reason is, that when dependabot merges a commit the token can not write to the repo
