### PR TITLE
Provide a default for `create_comment`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,7 @@ inputs:
   create_comment:
     required: false
     description: 'should the action comment on the pr'
+    default: 'false'
   check_title:
     required: false
     description: 'shall the title be checked?'


### PR DESCRIPTION
The action definition is missing the default value for `create_comment`, so even though is marked as optional, it is currently required.

If it is not specified, the action errors out when it should report an error:
```
Error: Input does not meet YAML 1.2 "Core Schema" specification: create_comment
Support boolean input list: `true | True | TRUE | false | False | FALSE`
```